### PR TITLE
Box draging fix

### DIFF
--- a/Insurgency_Core/client/bluforActions/fn_spawnAmmo.sqf
+++ b/Insurgency_Core/client/bluforActions/fn_spawnAmmo.sqf
@@ -17,8 +17,10 @@ clearMagazineCargoGlobal _box;
 clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
+private _boxPosition = getArray (configFile >> "CfgVehicles" >> _boxType >> "ace_dragging_dragPosition");
+
 [_box, _boxSize] call ace_cargo_fnc_setSize;
-[_box, true,[0,1.5,0]] call ace_dragging_fnc_setDraggable;
+[_box, true, _boxPosition] call ace_dragging_fnc_setDraggable;
 [_box, true] call ace_dragging_fnc_setCarryable;
 
 private _jipID = ["TWC_Insurgency_Actions_addDragging", [_box]] call CBA_fnc_globalEventJIP;

--- a/Insurgency_Core/client/bluforActions/fn_spawnAmmo.sqf
+++ b/Insurgency_Core/client/bluforActions/fn_spawnAmmo.sqf
@@ -18,7 +18,7 @@ clearItemCargoGlobal _box;
 clearBackpackCargoGlobal _box;
 
 [_box, _boxSize] call ace_cargo_fnc_setSize;
-[_box, true] call ace_dragging_fnc_setDraggable;
+[_box, true,[0,1.5,0]] call ace_dragging_fnc_setDraggable;
 [_box, true] call ace_dragging_fnc_setCarryable;
 
 private _jipID = ["TWC_Insurgency_Actions_addDragging", [_box]] call CBA_fnc_globalEventJIP;

--- a/Insurgency_Core/includes/loadouts/generic_ammoboxes.hpp
+++ b/Insurgency_Core/includes/loadouts/generic_ammoboxes.hpp
@@ -45,7 +45,6 @@ class Humanitarian_Aid {
 	size = 5;
 	cost = 5;
 	script = "_this call TWC_Insurgency_Actions_fnc_addGiveCrate";
-	ace_dragging_dragPosition[] = { 0, 2, 0 };
 	class Weapons {};
 	class Magazines {};
 	class Items {

--- a/Insurgency_Core/includes/loadouts/generic_ammoboxes.hpp
+++ b/Insurgency_Core/includes/loadouts/generic_ammoboxes.hpp
@@ -45,6 +45,7 @@ class Humanitarian_Aid {
 	size = 5;
 	cost = 5;
 	script = "_this call TWC_Insurgency_Actions_fnc_addGiveCrate";
+	ace_dragging_dragPosition[] = { 0, 2, 0 };
 	class Weapons {};
 	class Magazines {};
 	class Items {


### PR DESCRIPTION
The fn_spawnammo function set the boxes as dragable
For an unknown reason the default 1.5m offset was not aplied to these boxes
Thus I changed it so it will force a 1.5m offset always